### PR TITLE
throttle Qfoam production

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-var version = 0.025;
+var version = 0.026;
 var Univ = {};
 Univ.FPS = 8;
 Univ.Speedfactor = 1; // Factor to speed up everything -- for testing.
@@ -222,7 +222,7 @@ Univ.Object = function(id,type,singular,plural,number,infoblurb,VisibilityFcn,Co
 		return Math.max(interval, 1 / Univ.FPS);
 	}
 	
-	if(ProductionEquation == 'function'){
+	if(typeof ProductionEquation == 'function'){
 		this.ProductionEquation = ProductionEquation
 	} else {
 		this.ProductionEquation = function(){ return ProductionEquation; }
@@ -230,7 +230,7 @@ Univ.Object = function(id,type,singular,plural,number,infoblurb,VisibilityFcn,Co
 	this.Production = function(number){
 		var production = {};
 		var pe = this.ProductionEquation();
-		
+
 		var adder = 0;
 		var multiplier = 1;
 		var adderFunctions = [];
@@ -255,6 +255,7 @@ Univ.Object = function(id,type,singular,plural,number,infoblurb,VisibilityFcn,Co
 		}
 		
 		for(var item in pe){
+			
 			if(pe[item].type == 'lin'){
 				production[item] = pe[item].slope * number;
 			}
@@ -264,7 +265,7 @@ Univ.Object = function(id,type,singular,plural,number,infoblurb,VisibilityFcn,Co
 			else{ // Custom function
 				production[item] = pe[item].fcn(number);
 			}
-			
+
 			production[item] += adder;
 			for(var i in adderFunctions) production[item] += adderFunctions[i](item, this, production, number);
 			production[item] *= multiplier;
@@ -274,7 +275,7 @@ Univ.Object = function(id,type,singular,plural,number,infoblurb,VisibilityFcn,Co
 		return production;
 	}
 	
-	if(ConsumptionEquation == 'function'){
+	if(typeof ConsumptionEquation == 'function'){
 		this.ConsumptionEquation = ConsumptionEquation
 	} else {
 		this.ConsumptionEquation = function(){ return ConsumptionEquation; }
@@ -761,7 +762,7 @@ Univ.UpdateRates = function(){
 
 Univ.UpdateTimeTemp = function(){
 	Univ.Age =	1e-113 * Univ.Items['qfoam'].total_number +
-				1e-93 * Univ.Items['elementary'].total_number +
+				1e-93 * Univ.Items['elementary'].total_number / (1 + Math.exp(2*(-Math.log10(Univ.Age)+30))) + // 30 = sigmoid midpoint (-log10), 2 = steepness
 				2e-87 * Univ.Items['subatomic'].total_number +
 				6e-81 * Univ.Items['atom'].total_number;
 	Univ.Temp = 10000000000 * Math.pow(Univ.Age,-0.513);

--- a/generators.js
+++ b/generators.js
@@ -14,12 +14,16 @@ Univ.LoadObjects = function(){
 			}
 		},
 		4, // Base Interval
-		{ // ProductionEquation
-			qfoam: {
-				visible: 1,
-				type: 'lin',
-				slope: 1
+		function(){ // ProductionEquation
+			var qfoam_rate_factor = 1-1/(1+Math.exp(-2*(Math.log10(Univ.Age)+34)));
+			var production = {
+				qfoam: {
+					visible: 1,
+					type: 'lin',
+					slope: qfoam_rate_factor * 1
+				}
 			}
+			return production;
 		},
 		{}
 	);
@@ -37,12 +41,16 @@ Univ.LoadObjects = function(){
 			}
 		},
 		4, // Base Interval
-		{ // ProductionEquation
-			qfoam: {
-				visible: 1,
-				type: 'lin',
-				slope: 12
+		function(){ // ProductionEquation
+			var qfoam_rate_factor = 1-1/(1+Math.exp(-2*(Math.log10(Univ.Age)+34)));
+			var production = {
+				qfoam: {
+					visible: 1,
+					type: 'lin',
+					slope: qfoam_rate_factor * 12
+				}
 			}
+			return production;
 		},
 		{},
 		0 // no special Buy Function
@@ -61,12 +69,44 @@ Univ.LoadObjects = function(){
 			}
 		},
 		10, // Base Interval
-		{ // ProductionEquation
+		function() { // ProductionEquation
+			var qfoam_rate_factor = 1-1/(1+Math.exp(-2*(Math.log10(Univ.Age)+34)));
+			var production = {
+				qfoam: {
+					visible: 1,
+					type: 'lin',
+					slope: qfoam_rate_factor * 150
+				}
+			}
+			return production;
+		},
+		{},
+		0 // no special Buy Function
+	);
+	new Univ.Object('qfoam4','qfoam','Pym Particle Condenser','Pym Particle Condensers',0,
+	'Quantum Field Actuators generate even more Quantum Foam, even faster. It\'s what the people want. Well, people don\'t exist yet, but they would love this stuff.',
+		function(){ // isVisible
+			return Univ.Items['qfoam'].total_number >= 1000000 / 4;
+		},
+		{ // CostEquation
 			qfoam: {
 				visible: 1,
-				type: 'lin',
-				slope: 150
+				type: 'exp',
+				base: 1.01,
+				start: 1000000
 			}
+		},
+		10, // Base Interval
+		function() { // ProductionEquation
+			var qfoam_rate_factor = 1-1/(1+Math.exp(-2*(Math.log10(Univ.Age)+34)));
+			var production = {
+				qfoam: {
+					visible: 1,
+					type: 'lin',
+					slope: qfoam_rate_factor * 180000
+				}
+			}
+			return production;
 		},
 		{},
 		0 // no special Buy Function


### PR DESCRIPTION
It gets slowed down and approaches zero around 1e81 Qfoam.

Instead of requiring the user to make a crapload of boring Qfoam generators, we now have to enhance the production rates of the current ones, and give them plenty of upgrades etc, allowing the player to reach 1e81 Qfoam in a reasonable playtime.

The contribution of Elementary Particles to Univ.Age ramps up sigmoidally, so they don't block you from making more Qfoam just because you started making Elementary Particles early.